### PR TITLE
Fix booking form 404

### DIFF
--- a/api/submit-booking.js
+++ b/api/submit-booking.js
@@ -1,0 +1,59 @@
+const nodemailer = require('nodemailer');
+const { URLSearchParams } = require('url');
+
+async function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      resolve(Object.fromEntries(new URLSearchParams(body)));
+    });
+    req.on('error', err => {
+      reject(err);
+    });
+  });
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    return res.end('Method Not Allowed');
+  }
+
+  const { name, email, phone, service, date, message } = await parseBody(req);
+
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: 'ashathdavid@gmail.com',
+      pass: 'ASHATHdavid1998.'
+    }
+  });
+
+  const mailOptions = {
+    from: email,
+    to: 'ashathdavid@gmail.com',
+    replyTo: email,
+    subject: 'New Booking from Havre De La Calme Website',
+    html: `
+      <h2>New Client Booking</h2>
+      <p><strong>Name:</strong> ${name}</p>
+      <p><strong>Email:</strong> ${email}</p>
+      <p><strong>Phone:</strong> ${phone}</p>
+      <p><strong>Service:</strong> ${service}</p>
+      <p><strong>Preferred Date:</strong> ${date}</p>
+      <p><strong>Message:</strong> ${message}</p>
+    `
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+    res.end('Thank you for your booking. We will get back to you shortly.');
+  } catch (err) {
+    console.error('Error sending email:', err);
+    res.statusCode = 500;
+    res.end('There was an error sending your booking.');
+  }
+};

--- a/booking.html
+++ b/booking.html
@@ -173,7 +173,7 @@
 
 <div class="booking-form">
     <h2>Book Your Session</h2>
-    <form action="/submit-booking" method="POST" id="bookingForm">
+    <form action="/api/submit-booking" method="POST" id="bookingForm">
         <div class="form-group">
             <label for="name">Full Name:</label>
             <input type="text" id="name" name="name" required>

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
     	<div class="container">
 	    	<div class="row justify-content-end">
                         <div class="col-lg-4">
-                                                <form action="/submit-booking" method="POST" class="appointment-form">
+                                                <form action="/api/submit-booking" method="POST" class="appointment-form">
                                                         <h3 class="mb-3">Book your apartment</h3>
                                                         <div class="row">
                                                                 <div class="col-md-12">


### PR DESCRIPTION
## Summary
- create a serverless `/api/submit-booking` handler with nodemailer
- send form data to `/api/submit-booking` instead of `/submit-booking`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68517c8943f48329a6e220bb8e07650a