### PR TITLE
Add privacy and terms pages with footer links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -279,8 +279,8 @@
 	          </div>
 	          <div class="col-md-6 col-lg-4 text-md-right">
 	          	<p class="mb-0 list-unstyled">
-	          		<a class="mr-md-3" href="#">Terms</a>
-	          		<a class="mr-md-3" href="#">Privacy</a>
+	          		<a class="mr-md-3" href="terms.html">Terms of Use</a>
+	          		<a class="mr-md-3" href="privacy.html">Privacy Policy</a>
 	          		<a class="mr-md-3" href="#">Compliances</a>
 	          	</p>
 	          </div>

--- a/index.html
+++ b/index.html
@@ -699,8 +699,8 @@
 	          </div>
 	          <div class="col-md-6 col-lg-4 text-md-right">
 	          	<p class="mb-0 list-unstyled">
-	          		<a class="mr-md-3" href="#">Terms</a>
-	          		<a class="mr-md-3" href="#">Privacy</a>
+	          		<a class="mr-md-3" href="terms.html">Terms of Use</a>
+	          		<a class="mr-md-3" href="privacy.html">Privacy Policy</a>
 	          		<a class="mr-md-3" href="#">Compliances</a>
 	          	</p>
 	          </div>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Privacy Policy - Havre De La Calme</title>
+  <link rel="stylesheet" href="css/bootstrap.min.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="container py-5">
+    <h1>Privacy Policy</h1>
+    <p>This page outlines how Havre De La Calme collects and uses personal information.</p>
+  </div>
+</body>
+</html>

--- a/rooms.html
+++ b/rooms.html
@@ -248,8 +248,8 @@
 	          </div>
 	          <div class="col-md-6 col-lg-4 text-md-right">
 	          	<p class="mb-0 list-unstyled">
-	          		<a class="mr-md-3" href="#">Terms</a>
-	          		<a class="mr-md-3" href="#">Privacy</a>
+	          		<a class="mr-md-3" href="terms.html">Terms of Use</a>
+	          		<a class="mr-md-3" href="privacy.html">Privacy Policy</a>
 	          		<a class="mr-md-3" href="#">Compliances</a>
 	          	</p>
 	          </div>

--- a/services.html
+++ b/services.html
@@ -264,8 +264,8 @@
 	          </div>
 	          <div class="col-md-6 col-lg-4 text-md-right">
 	          	<p class="mb-0 list-unstyled">
-	          		<a class="mr-md-3" href="#">Terms</a>
-	          		<a class="mr-md-3" href="#">Privacy</a>
+	          		<a class="mr-md-3" href="terms.html">Terms of Use</a>
+	          		<a class="mr-md-3" href="privacy.html">Privacy Policy</a>
 	          		<a class="mr-md-3" href="#">Compliances</a>
 	          	</p>
 	          </div>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Terms of Use - Havre De La Calme</title>
+  <link rel="stylesheet" href="css/bootstrap.min.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="container py-5">
+    <h1>Terms of Use</h1>
+    <p>These terms govern your use of the Havre De La Calme website.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `privacy.html` and `terms.html`
- update footer links across pages to point to new documents

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857b781fc408329a5b5b35fe46c1d2c